### PR TITLE
bump node version -> 14 as 12 doesn't seem to work with most recent serve versions. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.2
+FROM node:14
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
When I tried running it with image `node:12.16.2` it kept crashing with "Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /usr/local/lib/node_modules/serve/build/main.js". Bumping the node image to 14 fixed this issue.

Alternative fix would be to install a specific `serve` from npm instead of the latest one.